### PR TITLE
change logic usePlugin

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -4,8 +4,9 @@ import { installNavigation } from "./navigation.js"
 
 const registeredPlugins = []
 
-const usePlugin = (plugin, options) => {
+const usePlugin = (app, plugin, options) => {
 	registeredPlugins.push({plugin, options})
+	app.use(plugin, options)
 }
 
 const applyPlugins = (app) => {
@@ -22,6 +23,7 @@ const registerComponents = (app) => {
 const registerAll = (app) => {
 	registerComponents(app)
 	installNavigation(app)
+	app.usePlugin = (plugin, options) => usePlugin(app, plugin, options)
 	applyPlugins(app)
 }
 

--- a/src/register.js
+++ b/src/register.js
@@ -4,6 +4,11 @@ import { installNavigation } from "./navigation.js"
 
 const registeredPlugins = []
 
+const installAndApplyPlugin = (app) => {
+	app.usePlugin = (plugin, options) => usePlugin(app, plugin, options)
+	applyPlugins(app)
+}
+
 const usePlugin = (app, plugin, options) => {
 	registeredPlugins.push({plugin, options})
 	app.use(plugin, options)
@@ -23,8 +28,7 @@ const registerComponents = (app) => {
 const registerAll = (app) => {
 	registerComponents(app)
 	installNavigation(app)
-	app.usePlugin = (plugin, options) => usePlugin(app, plugin, options)
-	applyPlugins(app)
+	installAndApplyPlugin(app)
 }
 
 export { registerComponents, registerAll, usePlugin, applyPlugins }


### PR DESCRIPTION
To add plugins the developer had to do this:
```ts
const app = createApp(App);
usePlugin(pinia)
usePlugin(router)

applyPlugins(app) <- apply plugins, this does not exist in vue
app.$run();
```
If you didn't want to use applyPlugins you had to declare usePlugin(xx) before createApp. The order shouldn't matter and it's weird for anyone coming from vue.js

```ts
usePlugin(pinia)
usePlugin(router)

const app = createApp(App);
app.$run();
```

This PR makes it work like this. Now the user can do his initialization like this, this follows the vue 3 convention
```ts
const app = createApp(App);
app.usePlugin(pinia)
app.usePlugin(router)

app.$run();
```